### PR TITLE
Another fix i didn't see before testing tick loading...

### DIFF
--- a/ConsoleExamples/Examples/mytests/config.cs
+++ b/ConsoleExamples/Examples/mytests/config.cs
@@ -10,8 +10,8 @@ namespace Encog.Examples.CSVMarketExample
         public static readonly int TRAINING_MINUTES = 1;
         public static readonly int HIDDEN1_COUNT = 20;
         public static readonly int HIDDEN2_COUNT;
-        public static readonly int INPUT_WINDOW = 10;
-        public static readonly int PREDICT_WINDOW = 1;
+        public static readonly int INPUT_WINDOW = 30;
+        public static readonly int PREDICT_WINDOW = 3;
         public static readonly TickerSymbol TICKER = new TickerSymbol("EURUSD");
     }
 }

--- a/ConsoleExamples/Examples/mytests/marketbuildtraining.cs
+++ b/ConsoleExamples/Examples/mytests/marketbuildtraining.cs
@@ -18,7 +18,9 @@ namespace Encog.Examples.CSVMarketExample
             FileInfo dataDir = new FileInfo(@Environment.CurrentDirectory);
             IMarketLoader loader = new CSVFileLoader();
             var market = new MarketMLDataSet(loader,Config.INPUT_WINDOW, Config.PREDICT_WINDOW);
-            var desc = new MarketDataDescription(Config.TICKER, MarketDataType.Close, true, true);
+          //  var desc = new MarketDataDescription(Config.TICKER, MarketDataType.Close, true, true);
+
+            var desc = new MarketDataDescription(Config.TICKER, MarketDataType.Trade, true, true);
             market.AddDescription(desc);
             string currentDirectory =@"c:\";
             loader.GetFile(fileName);
@@ -28,9 +30,10 @@ namespace Encog.Examples.CSVMarketExample
 
             // Gather training data for the last 2 years, stopping 60 days short of today.
             // The 60 days will be used to evaluate prediction.
-            begin = begin.AddDays(-60);
-            end = end.AddDays(-60);
-            begin = begin.AddYears(-2);
+            begin = begin.AddDays(-200);
+            end = begin.AddDays(1);
+           
+            Console.WriteLine("You are loading date from:" + begin.ToShortDateString() + " To :" + end.ToShortDateString());
 
             market.Load(begin, end);
             market.Generate();

--- a/ConsoleExamples/Examples/mytests/marketevaluate.cs
+++ b/ConsoleExamples/Examples/mytests/marketevaluate.cs
@@ -34,8 +34,11 @@ namespace Encog.Examples.CSVMarketExample
 
             var result = new MarketMLDataSet(loader,
                                              Config.INPUT_WINDOW, Config.PREDICT_WINDOW);
+          //  var desc = new MarketDataDescription(Config.TICKER,
+                                              //   MarketDataType.Close, true, true);
+
             var desc = new MarketDataDescription(Config.TICKER,
-                                                 MarketDataType.Close, true, true);
+                                     MarketDataType.Trade, true, true);
             result.AddDescription(desc);
 
             var end = DateTime.Now; // end today

--- a/ConsoleExamples/Examples/mytests/mytests.cs
+++ b/ConsoleExamples/Examples/mytests/mytests.cs
@@ -113,7 +113,7 @@ namespace Encog.Examples.CSVMarketExample
                 }
             }
 
-
+              
             catch (Exception ex)
             {
 

--- a/encog-core-cs/ML/Data/Market/Loader/csvfileloader.cs
+++ b/encog-core-cs/ML/Data/Market/Loader/csvfileloader.cs
@@ -22,33 +22,43 @@ namespace Encog.ML.Data.Market.Loader
         {
             try
             {
-
-
                 //We got a file, lets load it.
-
-
-
                 ICollection<LoadedMarketData> result = new List<LoadedMarketData>();
                 ReadCSV csv = new ReadCSV(File, true, CSVFormat.English);
                 csv.DateFormat = "yyyy.MM.dd HH:mm:ss";
 
+                DateTime ParsedDate = from;
 
-               
+
                 //  Time,Open,High,Low,Close,Volume
-                while (csv.Next())
+                while (csv.Next() && ParsedDate >= from && ParsedDate <= to  )
                 {
                     DateTime date = csv.GetDate("Time");
-                    double open = csv.GetDouble("Open");
-                    double close = csv.GetDouble("High");
-                    double high = csv.GetDouble("Low");
-                    double low = csv.GetDouble("Close");
-                    double volume = csv.GetDouble("Volume");
+                    double Bid= csv.GetDouble("Bid");
+                    double Ask = csv.GetDouble("Ask");
+                    double AskVolume = csv.GetDouble("AskVolume");
+                    double BidVolume= csv.GetDouble("BidVolume");
+                    double _trade = ( Bid + Ask ) /2;
+                    double _tradeSize = (AskVolume + BidVolume) / 2;
                     LoadedMarketData data = new LoadedMarketData(date, symbol);
-                    data.SetData(MarketDataType.Open, open);
-                    data.SetData(MarketDataType.High, high);
-                    data.SetData(MarketDataType.Low, low);
-                    data.SetData(MarketDataType.Close, close);
-                    data.SetData(MarketDataType.Volume, volume);
+                    data.SetData(MarketDataType.Trade, _trade);
+                    data.SetData(MarketDataType.Volume, _tradeSize);
+                    result.Add(data);
+
+                    Console.WriteLine("Current DateTime:"+ParsedDate.ToShortDateString()+ " Time:"+ParsedDate.ToShortTimeString() +"  Start date was "+from.ToShortDateString());
+                    Console.WriteLine("Stopping at date:" + to.ToShortDateString() );
+                    ParsedDate = date;
+                    //double open = csv.GetDouble("Open");
+                    //double close = csv.GetDouble("High");
+                    //double high = csv.GetDouble("Low");
+                    //double low = csv.GetDouble("Close");
+                    //double volume = csv.GetDouble("Volume");
+                    //LoadedMarketData data = new LoadedMarketData(date, symbol);
+                    //data.SetData(MarketDataType.Open, open);
+                    //data.SetData(MarketDataType.High, high);
+                    //data.SetData(MarketDataType.Low, low);
+                    //data.SetData(MarketDataType.Close, close);
+                    //data.SetData(MarketDataType.Volume, volume);
                     result.Add(data);
                 }
 


### PR DESCRIPTION
Fixed the CSVLoader to load ONLY whatever the CSV from date to end date
is asking for.. Makes a HUGE difference when loading tick files (see the
forum example).  Modified the example to load ticks (versus the hourly
data first).
