### PR TITLE
CSVRange example + better csvloader for marketdataset (RangeMaker).

### DIFF
--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/InterestRate.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/InterestRate.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+    class InterestRate : IComparable<InterestRate>
+    {
+        private DateTime effectiveDate;
+        private double rate;
+
+        public InterestRate(DateTime effectiveDate, double rate)
+        {
+            this.effectiveDate = effectiveDate;
+            this.rate = rate;
+        }
+
+        public int CompareTo(InterestRate other)
+        {
+            return getEffectiveDate().CompareTo(other.getEffectiveDate());
+        }
+
+        /**
+         * @return the effectiveDate
+         */
+        public DateTime getEffectiveDate()
+        {
+            return this.effectiveDate;
+        }
+
+        /**
+         * @return the rate
+         */
+        public double getRate()
+        {
+            return this.rate;
+        }
+
+        /**
+         * @param effectiveDate
+         *            the effectiveDate to set
+         */
+        public void setEffectiveDate(DateTime effectiveDate)
+        {
+            this.effectiveDate = effectiveDate;
+        }
+
+        /**
+         * @param rate
+         *            the rate to set
+         */
+        public void setRate(double rate)
+        {
+            this.rate = rate;
+        }
+
+    }
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/RangeConfig.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/RangeConfig.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Encog.ML.Data.Market;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+    public class RangeConfig
+    {
+        public static readonly String TRAINING_FILE = "RangemarketData.egb";
+        public static readonly String NETWORK_FILE = "RangemarketNetwork.eg";
+        public static readonly String DIRECTORY = @"c:\EncogOutput";
+        public static readonly int TRAINING_MINUTES = 1;
+        public static readonly int HIDDEN1_COUNT = 50;
+        public static readonly int HIDDEN2_COUNT = 20;
+        public static readonly int INPUT_WINDOW = 10;
+        public static readonly int PREDICT_WINDOW = 1;
+        public static readonly TickerSymbol TICKER = new TickerSymbol("EURUSD");
+    }
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketbuildtraining.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketbuildtraining.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Encog.Engine.Network.Activation;
+using Encog.ML;
+using Encog.ML.Data;
+using Encog.ML.Data.Basic;
+using Encog.ML.Data.Market;
+using Encog.ML.Data.Market.Loader;
+using Encog.ML.Data.Temporal;
+using Encog.ML.Train;
+using Encog.ML.Train.Strategy;
+using Encog.Neural.Networks;
+using Encog.Neural.Networks.Training;
+using Encog.Neural.Networks.Training.Anneal;
+using Encog.Neural.Networks.Training.Propagation.Back;
+using Encog.Neural.Pattern;
+using Encog.Util.CSV;
+using Encog.Util.File;
+using Encog.Util.Simple;
+using NUnit.Framework;
+using SuperUtils = Encog.Util.NetworkUtil.NetworkUtility;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+
+    public class MarketBuildTraining
+    {
+        public static void Generate(string fileName)
+        {
+
+
+
+
+            GetStuffs();
+
+
+            //EncogUtility.SaveEGB(FileUtil.CombinePath(dataDir, Examples.RangeCalculators.RangeConfig.TRAINING_FILE), market);
+
+            //// create a network
+
+
+
+            //Console.WriteLine(@"Built training file , and saved it to:" + dataDir.DirectoryName);
+
+            ////BasicNetwork network =
+            ////    (BasicNetwork) MarketBuildTraining.NetworkBuilders.CreateFeedforwardNetwork(RangeConfig.INPUT_WINDOW,
+            ////                                                                                RangeConfig.PREDICT_WINDOW,
+            ////                                                                                RangeConfig.HIDDEN1_COUNT,
+            ////                                                                                RangeConfig.HIDDEN2_COUNT);
+            //// training file
+
+
+
+
+            //// train the neural network
+            ////  EncogUtility.TrainConsole(network, trainingSet, RangeConfig.TRAINING_MINUTES);
+            //NetworkBuilders.DualNetworksTrainer(market.InputNeuronCount, market.IdealSize,
+            //                                    Examples.RangeCalculators.RangeConfig.HIDDEN1_COUNT, Examples.RangeCalculators.RangeConfig.HIDDEN2_COUNT, market,
+            //                                    Examples.RangeCalculators.RangeConfig.NETWORK_FILE);
+
+
+        }
+
+   
+        [Test]
+        public static void GetStuffs()
+        {
+            string fileName = "c:\\EURUSD_Hourly_Bid_1999.03.04_2011.03.14.csv";
+            List<double> Opens = SuperUtils.QuickParseCSV(fileName, "Open");
+            List<double> High = SuperUtils.QuickParseCSV(fileName, "High");
+            List<double> Low = SuperUtils.QuickParseCSV(fileName, "Low");
+            List<double> Close = SuperUtils.QuickParseCSV(fileName, "Close");
+
+            double[] Opensd = new double[Opens.Count];
+            double[] Closed = new double[Close.Count];
+            double[] Highd = new double[High.Count];
+            double[] Lowd = new double[Low.Count];
+
+
+
+
+            Opensd= CreateNormalizatione(Opensd.ToArray());
+            Highd = CreateNormalizatione(High.ToArray());
+            Closed = CreateNormalizatione(Close.ToArray());
+            Lowd = CreateNormalizatione(Low.ToArray());
+
+
+
+        }
+        public IMLDataSet CreateSetFromInputs(double [][] input,int nbofInputs)
+        {
+            
+
+        }
+
+        public IMLDataSet GenerateTraining(double[][] input, double[][] ideal)
+        {
+            IMLDataSet result = new BasicMLDataSet(input, ideal);
+            return result;
+        }
+
+
+
+        public static double [] CreateNormalizatione(double [] input)
+        {
+            double [] results = SuperUtils.NormalizeThisArray(input);
+            return results;
+        }
+        public class PredictionInputs
+        {
+            private int _inputsize = 0;
+            private int _outputsize = 0;
+            private List<InterestRate> rates = new List<InterestRate>();
+            private List<FinancialSample> samples = new List<FinancialSample>();
+            private int inputSize;
+            private int outputSize;
+            public PredictionInputs(int inputSize, int outputSize)
+            {
+                this._inputsize = inputSize;
+                this._outputsize = outputSize;
+            }
+
+            public void GetInputData(int offset, double[] input)
+            {
+                Object[] samplesArray = samples.ToArray();
+                // get SP500 & prime data
+                for (int i = 0; i < this._inputsize; i++)
+                {
+                    FinancialSample sample = (FinancialSample)samplesArray[offset + i];
+                    input[i] = sample.GetPercent();
+                    input[i + this._outputsize] = sample.GetRate();
+                }
+            }
+            public double GetPrimeRate(DateTime date)
+            {
+                double currentRate = 0;
+                foreach (InterestRate rate in this.rates)
+                {
+                    if (rate.getEffectiveDate().CompareTo(date) > 0)
+                    {
+                        return currentRate;
+                    }
+                    else
+                    {
+                        currentRate = rate.getRate();
+                    }
+                }
+                return currentRate;
+            }
+
+
+
+            public IList<FinancialSample> GetSamples()
+            {
+                return this.samples;
+            }
+            public void Load(String sp500Filename,
+            String primeFilename)
+            {
+                loadSP500(sp500Filename);
+                loadPrime(primeFilename);
+                stitchInterestRates();
+                //CalculatePercents();
+            }
+            public void loadPrime(String primeFilename)
+            {
+                ReadCSV csv = new ReadCSV(primeFilename,true,CSVFormat.English);
+
+                while (csv.Next())
+                {
+                    DateTime date = csv.GetDate("date");
+                    double rate = csv.GetDouble("prime");
+                    InterestRate ir = new InterestRate(date, rate);
+                    this.rates.Add(ir);
+                }
+
+                csv.Close();
+                this.rates.Sort();
+            }
+
+            public void loadSP500(String sp500Filename)
+            {
+                ReadCSV csv = new ReadCSV(sp500Filename,true,CSVFormat.English);
+                while (csv.Next())
+                {
+                    DateTime date = csv.GetDate("date");
+                    double amount = csv.GetDouble("adj close");
+                    FinancialSample sample = new FinancialSample();
+                    sample.SetAmount(amount);
+                    sample.SetDate(date);
+                    this.samples.Add(sample);
+                }
+                csv.Close();
+                this.samples.Sort();
+            }
+
+            public int size()
+            {
+                return this.samples.Count;
+            }
+
+            public void stitchInterestRates()
+            {
+                foreach (FinancialSample sample in this.samples)
+                {
+                    double rate = GetPrimeRate(sample.GetDate());
+                    sample.SetRate(rate);
+                }
+            }
+
+
+            public class FinancialSample : IComparable<FinancialSample>
+            {
+                private double amount;
+                private double rate;
+                private DateTime date;
+                private double percent;
+                public int CompareTo(FinancialSample other)
+                {
+                    return GetDate().CompareTo(other.GetDate());
+                }
+                public double GetAmount()
+                {
+                    return this.amount;
+                }
+                public DateTime GetDate()
+                {
+                    return this.date;
+                }
+                public double GetPercent()
+                {
+                    return this.percent;
+                }
+                public double GetRate()
+                {
+                    return this.rate;
+                }
+                public void SetAmount(double amount)
+                {
+                    this.amount = amount;
+                }
+                public void SetDate(DateTime date)
+                {
+                    this.date = date;
+                }
+                public void SetPercent(double percent)
+                {
+                    this.percent = percent;
+                }
+                public void SetRate(double rate)
+                {
+                    this.rate = rate;
+                }
+                override public String ToString()
+                {
+                    StringBuilder result = new StringBuilder();
+                    result.Append(ReadCSV.ParseDate(date.ToShortDateString(), "yyyy/mm/dd"));
+                    result.Append(", Amount: ");
+                    result.Append(this.amount);
+                    result.Append(", Prime Rate: ");
+                    result.Append(this.rate);
+                    result.Append(", Percent from Previous: ");
+                    result.Append(this.percent.ToString("N2"));
+                    return result.ToString();
+
+                }
+
+            }
+        }
+
+    }
+
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketevaluate.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketevaluate.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.IO;
+using Encog.Engine.Network.Activation;
+using Encog.ML;
+using Encog.ML.Data;
+using Encog.ML.Data.Market;
+using Encog.ML.Data.Market.Loader;
+using Encog.ML.Data.Temporal;
+using Encog.Neural.Networks;
+using Encog.Neural.Pattern;
+using Encog.Util;
+using Encog.Util.File;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+    public class MarketEvaluate
+    {
+        #region Direction enum
+
+        public enum Direction
+        {
+            Up,
+            Down
+        } ;
+
+        #endregion
+
+        public static Direction DetermineDirection(double d)
+        {
+            return d < 0 ? Direction.Down : Direction.Up;
+        }
+       
+        public static MarketMLDataSet GrabData(string newfileLoad)
+        {
+            FileInfo dataDir = new FileInfo(@Environment.CurrentDirectory);
+            IMarketLoader loader = new RangeMaker();
+            loader.GetFile(newfileLoad);
+
+            var market = new MarketMLDataSet(loader, Examples.RangeCalculators.RangeConfig.INPUT_WINDOW, Examples.RangeCalculators.RangeConfig.PREDICT_WINDOW);
+
+
+            //var descClose = new MarketDataDescription(RangeConfig.TICKER, MarketDataType.Close, true, false);
+            //market.AddDescription(descClose);
+            //var descOpen = new MarketDataDescription(RangeConfig.TICKER, MarketDataType.Open, true, false);
+            //market.AddDescription(descOpen);
+            //var descHigh = new MarketDataDescription(RangeConfig.TICKER, MarketDataType.High, true, false);
+            //market.AddDescription(descHigh);
+            //var descLow = new MarketDataDescription(RangeConfig.TICKER, MarketDataType.Low, true, false);
+            //market.AddDescription(descLow);
+            //var ranges = new MarketDataDescription(RangeConfig.TICKER, MarketDataType.RangeOpenClose,
+            //                                       TemporalDataDescription.Type.Raw, true, false);
+           // market.AddDescription(ranges);
+            var RangeopenClose = new MarketDataDescription(Examples.RangeCalculators.RangeConfig.TICKER, MarketDataType.RangeHighLow,
+                                                           TemporalDataDescription.Type.Raw, true, true);
+            market.AddDescription(RangeopenClose);
+            var end = DateTime.Now; // end today
+            var begin = new DateTime(end.Ticks); // begin 30 days ago
+            // Gather training data for the last 2 years, stopping 60 days short of today.
+            // The 60 days will be used to evaluate prediction.
+            begin = begin.AddDays(-450);
+            end = begin.AddDays(60);
+
+            Console.WriteLine(@"You are loading date from:" + begin.ToShortDateString() + @" To :" +
+                              end.ToShortDateString());
+
+            market.Load(begin, end);
+            market.Generate();
+            return market;
+
+        }
+        
+        public static double DeterminePrice (double percentage , double currentPrice)
+        {
+            return (percentage*currentPrice) + currentPrice;
+        }
+        
+        public static IMLMethod CreateFeedforwardNetwork(int inputneurons, int outputsneurons, int hiddenNeurons, int hidden2)
+        {
+            // construct a feedforward type network
+            FeedForwardPattern pattern = new FeedForwardPattern();
+            pattern.ActivationFunction = new ActivationSigmoid();
+            pattern.InputNeurons = inputneurons;
+            pattern.AddHiddenLayer(hiddenNeurons);
+            pattern.AddHiddenLayer(hidden2);
+            pattern.OutputNeurons = outputsneurons;
+            return pattern.Generate();
+        }
+
+
+        //public static void Evaluate(FileInfo dataDir,string filename)
+        //{
+        //    FileInfo file = FileUtil.CombinePath(dataDir, Examples.RangeCalculators.RangeConfig.NETWORK_FILE);
+
+        //    if (!file.Exists)
+        //    {
+        //        Console.WriteLine(@"Can't read file: " + file);
+        //        return;
+        //    }
+
+        //    //var network = (BasicNetwork) EncogDirectoryPersistence.LoadObject(file);
+
+        //    MarketMLDataSet data = GrabData(filename);
+        //    var network = (BasicNetwork)  MarketBuildTraining.NetworkBuilders.CreateFeedforwardNetwork(data.InputNeuronCount, data.IdealSize,
+        //                                        Examples.RangeCalculators.RangeConfig.HIDDEN1_COUNT, Examples.RangeCalculators.RangeConfig.HIDDEN2_COUNT);
+
+
+        //    int count = 0;
+        //    int correct = 0;
+        //    foreach (IMLDataPair pair in data)
+        //    {
+        //        IMLData input = pair.Input;
+        //        IMLData actualData = pair.Ideal;
+        //        IMLData predictData = network.Compute(input);
+
+        //        double actual = actualData[0];
+        //        double predict = predictData[0];
+        //        double diff = Math.Abs(predict - actual);
+
+        //        Direction actualDirection = DetermineDirection(actual);
+        //        Direction predictDirection = DetermineDirection(predict);
+
+        //        if (actualDirection == predictDirection)
+        //            correct++;
+
+        //        count++;
+
+
+        //        Console.WriteLine(@"Day " + count + @":actual="
+        //                          + Format.FormatDouble(actual, 4) + @"(" + actualDirection + @")"
+        //                          + @",predict=" + Format.FormatDouble(predict, 4) + @"("
+        //                          + predictDirection + @")" + @",diff=" + diff);
+        //    }
+        //    double percent = correct/(double) count;
+        //    Console.WriteLine(@"Direction correct:" + correct + @"/" + count);
+        //    Console.WriteLine(@"Directional Accuracy:"
+        //                      + Format.FormatPercent(percent));
+        //}
+    }
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketpredict.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketpredict.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using ConsoleExamples.Examples;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+
+    public class RangeCalculators : IExample
+    {
+        public static ExampleInfo Info
+        {
+            get
+            {
+                var info = new ExampleInfo(
+                    typeof (RangeCalculators),
+                    "csvrange",
+                    "Simple Range Prediction",
+                    "Use csv data to predict ranges of a stock or forex, futures instrument.");
+                return info;
+            }
+        }
+
+        #region IExample Members
+
+        public void Execute(IExampleInterface app)
+        {
+            if (app.Args.Length < 1)
+            {
+                Console.WriteLine(@"csvRange [generate/train/prune/evaluate] PathToFile");
+                Console.WriteLine(@"e.g csvrange [generate/train/prune/evaluate] c:\\EURUSD.csv");
+                Console.WriteLine(@"csvrange train Directory");
+            }
+            else
+            {
+                FileInfo dataDir = new FileInfo(Environment.CurrentDirectory);
+                if (String.Compare(app.Args[0], "generate", true) == 0)
+                {
+                    MarketBuildTraining.Generate(app.Args[1]);
+                }
+                else if (String.Compare(app.Args[0], "train", true) == 0)
+                {
+                    Examples.RangeCalculators.MarketTrain.Train(dataDir);
+                }
+                else if (String.Compare(app.Args[0], "evaluate", true) == 0)
+                {
+                    //MarketEvaluate.Evaluate(dataDir,app.Args[1]);
+                }
+                else if (String.Compare(app.Args[0], "prune", true) == 0)
+                {
+                    {
+                        Examples.RangeCalculators.MarketPrune.Incremental(dataDir);
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketprune.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/marketprune.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using Encog.Engine.Network.Activation;
+using Encog.ML.Data;
+using Encog.Neural.Pattern;
+using Encog.Neural.Prune;
+using Encog.Persist;
+using Encog.Util.File;
+using Encog.Util.Simple;
+
+namespace Encog.Examples.RangeAndPredictions
+{
+
+    public class MarketPrune
+    {
+        public static void Incremental(FileInfo dataDir)
+        {
+            FileInfo file = FileUtil.CombinePath(dataDir, RangeConfig.TRAINING_FILE);
+
+            if (!file.Exists)
+            {
+                Console.WriteLine(@"Can't read file: " + file);
+                return;
+            }
+
+            IMLDataSet training = EncogUtility.LoadEGB2Memory(file);
+    
+
+            var pattern = new FeedForwardPattern
+                              {
+                                  InputNeurons = training.InputSize,
+                                  OutputNeurons = training.IdealSize,
+                                  ActivationFunction = new ActivationTANH()
+                              };
+
+            var prune = new PruneIncremental(training, pattern, 100, 1, 10,
+                                             new ConsoleStatusReportable());
+
+            prune.AddHiddenLayer(5, 50);
+            prune.AddHiddenLayer(0, 50);
+
+            prune.Process();
+
+            EncogDirectoryPersistence.SaveObject(file, prune.BestNetwork);
+        }
+    }
+}

--- a/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/markettrain.cs
+++ b/Last/fxmozart-encog-dotnet-core-24b300b/ConsoleExamples/Examples/SuperPredict/markettrain.cs
@@ -1,0 +1,102 @@
+﻿//using System;
+//using System.IO;
+//using Encog.ML.Data;
+//using Encog.ML.Train;
+//using Encog.ML.Train.Strategy;
+//using Encog.Neural.Networks;
+//using Encog.Neural.Networks.Training;
+//using Encog.Neural.Networks.Training.Anneal;
+//using Encog.Neural.Networks.Training.Propagation.Back;
+//using Encog.Persist;
+//using Encog.Util.File;
+//using Encog.Util.Simple;
+
+//namespace Encog.Examples.RangeAndPredictions
+//{
+
+//    public class MarketTrain
+//    {
+//        public static void Train(FileInfo dataDir)
+//        {
+//            FileInfo networkFile = FileUtil.CombinePath(dataDir, RangeCalculators.RangeConfig.NETWORK_FILE);
+//            FileInfo trainingFile = FileUtil.CombinePath(dataDir, RangeCalculators.RangeConfig.TRAINING_FILE);
+
+//            // network file
+//            if (!networkFile.Exists)
+//            {
+//                Console.WriteLine(@"Can't read file: " + networkFile);
+//                return;
+//            }
+
+//       //     var network = (BasicNetwork) Utilities.LoadNetwork(Environment.CurrentDirectory, RangeConfig.NETWORK_FILE);
+
+//            BasicNetwork network = (BasicNetwork)MarketBuildTraining.NetworkBuilders.CreateFeedforwardNetwork(RangeCalculators.RangeConfig.INPUT_WINDOW,
+//                                                                        RangeCalculators.RangeConfig.PREDICT_WINDOW,
+//                                                                        RangeCalculators.RangeConfig.HIDDEN1_COUNT,
+//                                                                        RangeCalculators.RangeConfig.HIDDEN2_COUNT);
+//            // training file
+//            if (!trainingFile.Exists)
+//            {
+//                Console.WriteLine(@"Can't read file: " + trainingFile);
+//                return;
+//            }
+
+//            var trainingSet = EncogUtility.LoadEGB2Memory(trainingFile);
+
+//            // train the neural network
+//            //  EncogUtility.TrainConsole(network, trainingSet, RangeConfig.TRAINING_MINUTES);
+
+//            TrainNetwork("Feedforward", network, trainingSet);
+
+//            //Console.WriteLine(@"Final Error: " + network.CalculateError(trainingSet));
+//            Console.WriteLine(@"Training complete, saving network.");
+//            EncogDirectoryPersistence.SaveObject(networkFile, network);
+//            Console.WriteLine(@"Network saved.");
+//            EncogFramework.Instance.Shutdown();
+//        }
+
+
+//        private static double TrainNetwork(String what, BasicNetwork network, IMLDataSet set)
+//        {
+//            // train the neural network
+//            ICalculateScore score = new TrainingSetScore(set);
+//            IMLTrain trainAlt = new NeuralSimulatedAnnealing(
+//                network, score, 10, 2, 100);
+
+
+//            IMLTrain trainMain = new Backpropagation(network, set, 0.00001, 0.0);
+
+//            var stop = new StopTrainingStrategy();
+//            trainMain.AddStrategy(new Greedy());
+//            //trainMain.AddStrategy(new HybridStrategy(trainAlt));
+//            trainMain.AddStrategy(stop);
+
+//            int epoch = 0;
+//            int geneticIterations = 0;
+
+//            while (!stop.ShouldStop())
+//            {
+//                if (trainAlt.IterationNumber > geneticIterations)
+//                {
+//                    Console.WriteLine(@"Current Genetic Iteration:" + trainAlt.IterationNumber);
+//                    geneticIterations = trainAlt.IterationNumber;
+
+//                }
+//                trainMain.Iteration();
+//                Console.WriteLine(@"Training " + what + @", Epoch #" + epoch + @" Error:" + trainMain.Error + @" Genetic #" + trainAlt.IterationNumber + @" Genetic Error:" + trainAlt.Error);
+//                epoch++;
+//            }
+//            //EncogUtility.TrainDialog(trainMain, network, trainingSet);
+
+//            if (what.Equals(@"Feedforward"))
+//            {
+//                Encog.Util.NetworkUtil.NetworkUtility.SaveNetwork(Environment.CurrentDirectory, RangeCalculators.RangeConfig.NETWORK_FILE,
+//                                                                  network);
+//                Console.WriteLine(@"Saved the Feedforward network");
+//            }
+
+
+//            return trainMain.Error;
+//        }
+//    }
+//}


### PR DESCRIPTION
Evaluate works, prune , predict , train..

CsvRange example predicts ranges in a timeseries (using marketdataset).

Also added a method to get percent changes in a double serie (removing the need to normalize..works fast..In networkutilities).

RangeMaker actually does everything, closing, open, etc...But 3 new : Open/close (range) , High/Low , Open/Close no abs (with directional movement possible predictions).
