### PR TITLE
Fixed EndMinutesStrategy to correctly evaluate ShouldStop after the specified number of minutes have elapsed.

### DIFF
--- a/encog-core-cs/ML/Train/Strategy/End/EndMinutesStrategy.cs
+++ b/encog-core-cs/ML/Train/Strategy/End/EndMinutesStrategy.cs
@@ -86,7 +86,7 @@ namespace Encog.ML.Train.Strategy.End
         {
             lock (this)
             {
-                return _started && _minutesLeft >= 0;
+                return _started && _minutesLeft <= 0;
             }
         }
 
@@ -94,7 +94,7 @@ namespace Encog.ML.Train.Strategy.End
         public virtual void Init(IMLTrain train)
         {
             _started = true;
-            _startedTime = DateTime.Now.Millisecond;
+            _startedTime = DateTime.Now.Ticks;
         }
 
         /// <inheritdoc/>
@@ -102,8 +102,10 @@ namespace Encog.ML.Train.Strategy.End
         {
             lock (this)
             {
-                long now = DateTime.Now.Millisecond;
-                _minutesLeft = ((int) ((now - _startedTime)/60000));
+                long now = DateTime.Now.Ticks;
+                long elapsedTicks = now - _startedTime;
+                int elapsedMinutes = (int)(elapsedTicks / TimeSpan.TicksPerMinute);
+                _minutesLeft = _minutes - elapsedMinutes;
             }
         }
 


### PR DESCRIPTION
This class did not survive the transition from Java to .NET. Instead of returning the number of milliseconds in the UNIX epoch like System.currentTimeMillis() in Java, DateTime.Now.Millisecond returns the number of milliseconds elapsed in the current second, so it will never exceed a single second. The corresponding epoch time to use is DateTime.Now.Ticks, which returns the number of 100ns intervals elapsed since 1/1/0001. I've changed the class to use DateTime.Now.Ticks.
