### PR TITLE
Fix Out Of Range Bug In BasicMLSequenceSet.

### DIFF
--- a/encog-core-cs/ML/Data/Basic/BasicMLSequenceSet.cs
+++ b/encog-core-cs/ML/Data/Basic/BasicMLSequenceSet.cs
@@ -243,19 +243,18 @@ namespace Encog.ML.Data.Basic
         {
             get
             {
-				int sequenceIndex = 0;
-				int recordIndex = x;
-				while(_sequences[sequenceIndex].Count < recordIndex)
-				{
-					recordIndex -= _sequences[sequenceIndex].Count;
-					sequenceIndex++;
-					if(sequenceIndex > _sequences.Count)
-					{
-						throw new MLDataError("Record out of range: " + x);
-					}
-				}
-
-				return _sequences[sequenceIndex][recordIndex];
+                int sequenceIndex = 0;
+                int recordIndex = x;
+                while(_sequences[sequenceIndex].Count <= recordIndex)
+                {
+                    recordIndex -= _sequences[sequenceIndex].Count;
+                    sequenceIndex++;
+                    if(sequenceIndex > _sequences.Count)
+                    {
+                        throw new MLDataError("Record out of range: " + x);
+                    }
+                }
+                return _sequences[sequenceIndex][recordIndex];
             }
         }
 


### PR DESCRIPTION
In the while loop, _sequences[sequenceIndex].Count should less equal than recordIndex, not less than. The origin version will cause exception when travel this dataset by

```
for(var i=0;i < seq.Count; ++i){
    var tmp = seq[i];
}
```
