### PR TITLE
Made a little optimization on the Equilateral Encoding code.

### DIFF
--- a/encog-core-cs/MathUtil/Equilateral.cs
+++ b/encog-core-cs/MathUtil/Equilateral.cs
@@ -123,7 +123,7 @@ namespace Encog.MathUtil
         /// <param name="low"> The low end of the range of values to generate.</param>
         /// <returns>One row for each set, the columns are the activations for that set.</returns>
         private static double[][] Equilat(int n,
-                                   double high, double low)
+                                   double high = 1, double low = -1)
         {
             var result = new double[n][]; // n - 1
             for (int i = 0; i < n; i++)
@@ -160,7 +160,10 @@ namespace Encog.MathUtil
                 result[k][k - 1] = 1.0;
             }
 
-            // scale it
+            // scale it if it's not [-1, 1]
+            if (low == -1 && high == 1)
+                return result;
+
             for (int row = 0; row < result.GetLength(0); row++)
             {
                 for (int col = 0; col < result[0].GetLength(0); col++)


### PR DESCRIPTION
I started reading the first book and am currently in the Equilateral encoding part. I believe the scaling is only needed when the range is different from -1 and 1. I also defaulted the low and high values in the parameters so that you could only write n if you wished to use -1 and 1 range (I think that range might be used quite often, but as I'm just starting with AI I might be wrong). Please correct me if this is wrong or unnecessary as I'm not sure if I understood the algorithm or code completely.