### PR TITLE
Arithmetic overflow when running 32 CPUs -> Fix for it

### DIFF
--- a/encog-core-cs/Util/Concurrency/DetermineWorkload.cs
+++ b/encog-core-cs/Util/Concurrency/DetermineWorkload.cs
@@ -66,7 +66,7 @@ namespace Encog.Util.Concurrency
             _workloadSize = workloadSize;
             if (threads == 0)
             {
-                var num = (int) (Math.Log(((long) Process.GetCurrentProcess().ProcessorAffinity.ToInt64() + 1), 2));
+                var num = Environment.ProcessorCount;
 
                 // if there is more than one processor, use processor count +1
                 if (num != 1)

--- a/encog-core-cs/Util/Concurrency/DetermineWorkload.cs
+++ b/encog-core-cs/Util/Concurrency/DetermineWorkload.cs
@@ -66,7 +66,7 @@ namespace Encog.Util.Concurrency
             _workloadSize = workloadSize;
             if (threads == 0)
             {
-                var num = (int) (Math.Log(((int) Process.GetCurrentProcess().ProcessorAffinity + 1), 2));
+                var num = (int) (Math.Log(((long) Process.GetCurrentProcess().ProcessorAffinity.ToInt64() + 1), 2));
 
                 // if there is more than one processor, use processor count +1
                 if (num != 1)


### PR DESCRIPTION
When running the code on a system with 32 (virtual) CPUs, the Process.GetCurrentProcess().ProcessorAffinity overflows 32-bit integer.
Example of such system is c4.8xlarge at Amazon,
