### PR TITLE
Temporary Encog Normalization Extensions Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ encog-core-cs.sln.vsdoc
 EncogCmd/EncogCmd.csproj.vs10x
 encog-core-cs/encog-core-cs.vsdoc
 encog-core-cs.5.1.ReSharper.user.orig
+encog-extensions-test/bin
+encog-extensions-test/obj
+EncogExtensions/bin
+EncogExtensions/obj

--- a/EncogExtensions/Normalization/AnalystNormalizeDataSet.cs
+++ b/EncogExtensions/Normalization/AnalystNormalizeDataSet.cs
@@ -1,0 +1,129 @@
+﻿using Encog.App.Analyst;
+using Encog.App.Analyst.Missing;
+using Encog.App.Analyst.Script.Normalize;
+using Encog.Util.Arrayutil;
+using System;
+using System.Data;
+
+namespace EncogExtensions.Normalization
+{
+    public class AnalystNormalizeDataSet
+    {
+        private EncogAnalyst _analyst;
+
+        public AnalystNormalizeDataSet(EncogAnalyst analyst)
+        {
+            this._analyst = analyst;
+        }
+
+        public double[,] Normalize(DataSet dataSet)
+        {
+            int outputLength = _analyst.DetermineTotalColumns();
+            double[,] result = new double[dataSet.Tables[0].Rows.Count, outputLength];
+
+            for (var irow = 0; irow < dataSet.Tables[0].Rows.Count; irow++)
+            {
+                var normalizedRowFields = ExtractFields(_analyst, dataSet.Tables[0].Rows[irow], outputLength, false);
+                if (normalizedRowFields != null)
+                {
+                    for (var iNormColumn = 0; iNormColumn < outputLength; iNormColumn++)
+                    {
+                        result[irow, iNormColumn] = normalizedRowFields[iNormColumn];
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private double[] ExtractFields(EncogAnalyst analyst, DataRow rowData, int outputLength, bool v)
+        {
+            var output = new double[outputLength];
+            int outputIndex = 0;
+
+            foreach (AnalystField stat in analyst.Script.Normalize.NormalizedFields)
+            {
+                stat.Init();
+                if (stat.Action == NormalizationAction.Ignore)
+                {
+                    continue;
+                }
+
+                var index = Array.FindIndex(analyst.Script.Fields, x => x.Name == stat.Name);
+                var str = rowData[index].ToString();
+                // is this an unknown value?
+                if (str.Equals("?") || str.Length == 0)
+                {
+                    IHandleMissingValues handler = analyst.Script.Normalize.MissingValues;
+                    double[] d = handler.HandleMissing(analyst, stat);
+
+                    // should we skip the entire row
+                    if (d == null)
+                    {
+                        return null;
+                    }
+
+                    // copy the returned values in place of the missing values
+                    for (int i = 0; i < d.Length; i++)
+                    {
+                        output[outputIndex++] = d[i];
+                    }
+                }
+                else
+                {
+                    // known value
+
+                    if (stat.Action == NormalizationAction.Normalize)
+                    {
+                        double d = double.Parse(str.Trim());
+                        d = stat.Normalize(d);
+                        output[outputIndex++] = d;
+                    }
+                    else if (stat.Action == NormalizationAction.PassThrough)
+                    {
+                        double d = double.Parse(str);
+                        output[outputIndex++] = d;
+                    }
+                    else
+                    {
+                        double[] d = stat.Encode(str.Trim());
+
+                        foreach (double element in d)
+                        {
+                            output[outputIndex++] = element;
+                        }
+                    }
+                }
+            }
+
+            return output;
+        }
+
+        /*
+                private double[] ExtractFields(EncogAnalyst _analyst, DataSet dataSet, bool skipOutput)
+                {
+                    var output = new List<double>();
+                    int outputIndex = 0;
+
+                    foreach (AnalystField stat in _analyst.Script.Normalize.NormalizedFields)
+                    {
+                        stat.Init();
+                        if (stat.Action == NormalizationAction.Ignore)
+                        {
+                            continue;
+                        }
+
+                        if (stat.Output && skipOutput)
+                        {
+                            continue;
+                        }
+
+                        if(stat.Action == NormalizationAction.Normalize)
+                        {
+                            output[outputIndex] =
+                        }
+                    }
+                }
+          */
+    }
+}

--- a/EncogExtensions/Normalization/AnalystWizardExtensions.cs
+++ b/EncogExtensions/Normalization/AnalystWizardExtensions.cs
@@ -1,0 +1,41 @@
+﻿using Encog.App.Analyst;
+using Encog.App.Analyst.Wizard;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace EncogExtensions.Normalization
+{
+    public static class AnalystWizardExtensions
+    {
+
+
+        public static void Wizard(this AnalystWizard wizard, DataSet data)
+        {
+            EncogAnalyst analyst = wizard.GetPrivateField<EncogAnalyst>("_analyst");
+            int lagWindowSize = wizard.GetPrivateField<int>("_lagWindowSize");
+            int leadWindowSize = wizard.GetPrivateField<int>("_leadWindowSize");
+
+            wizard.SetPrivateField("_timeSeries", (lagWindowSize > 0 || leadWindowSize > 0));
+           
+            wizard.CallPrivateMethod("DetermineClassification");
+            wizard.CallPrivateMethod("GenerateSettings");
+            
+           
+            analyst.Analyze(data);
+
+
+            wizard.CallPrivateMethod("GenerateNormalizedFields");
+            wizard.CallPrivateMethod("GenerateSegregate");
+            wizard.CallPrivateMethod("GenerateGenerate");
+            wizard.CallPrivateMethod("GenerateTasks");
+
+            if (wizard.GetPrivateField<bool>("_timeSeries") 
+                && (lagWindowSize > 0) 
+                && (leadWindowSize > 0))
+            {
+                wizard.CallPrivateMethod("ExpandTimeSlices");
+            }
+        }
+    }
+}

--- a/EncogExtensions/Normalization/DatasetExtensions.cs
+++ b/EncogExtensions/Normalization/DatasetExtensions.cs
@@ -1,0 +1,78 @@
+﻿using Encog.ML.Data.Market;
+using Encog.ML.Data.Market.Loader;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace EncogExtensions.Normalization
+{
+    public static class DatasetExtensions
+    {
+        public static DataSet Convert(this DataSet dataSet, List<LoadedMarketData> data, string dataSetName = "dataset")
+        {
+            if (data.Count < 1)
+            {
+                throw new ArgumentOutOfRangeException("Loaded Market Data passed to DataSet.Convert() method appears to be empty (Contains 0 Rows).");
+            }
+
+            var resultDataSet = new DataSet("dataset");
+            DataTable table = new DataTable("Market Data Table");
+
+            var dataRowCount = data.Count();
+            var initialDataColumns = new List<DataColumn>();
+
+            AddInitialColumn(initialDataColumns, "StockSymbol", typeof(String));
+            AddInitialColumn(initialDataColumns, "Day", typeof(int));
+            AddInitialColumn(initialDataColumns, "Month", typeof(int));
+            AddInitialColumn(initialDataColumns, "Year", typeof(int));
+            CopyInitialColumnsToTable(table, initialDataColumns);
+
+            var dataColumnInitialIndex = initialDataColumns.Count;
+
+            foreach (KeyValuePair<MarketDataType, double> column in data[0].Data)
+            {
+                DataColumn dataColumn = new DataColumn(column.Key.ToString());
+                dataColumn.DataType = column.Value.GetType();
+                table.Columns.Add(dataColumn);
+                dataColumnInitialIndex++;
+            }
+
+            for (var dataRowIndex = 0; dataRowIndex < dataRowCount; dataRowIndex++)
+            {
+                var row = table.NewRow();
+                row[0] = data[dataRowIndex].Ticker.Symbol; // stock symbol
+                row[1] = data[dataRowIndex].When.Day;
+                row[2] = data[dataRowIndex].When.Month;
+                row[3] = data[dataRowIndex].When.Year;
+
+                var dataColumnIndex = initialDataColumns.Count;
+
+                foreach (KeyValuePair<MarketDataType, double> entry in data[dataRowIndex].Data)
+                {
+                    row[dataColumnIndex] = entry.Value;
+                    dataColumnIndex++;
+                }
+
+                table.Rows.Add(row);
+            }
+
+            resultDataSet.Tables.Add(table);
+
+            return resultDataSet;
+        }
+
+        private static void CopyInitialColumnsToTable(DataTable table, List<DataColumn> initialDataColumns)
+        {
+            table.Columns.AddRange(initialDataColumns.ToArray());
+        }
+
+        private static void AddInitialColumn(List<DataColumn> initialDataColumns, string name, Type dataType)
+        {
+            DataColumn InitialColumn = null;
+            InitialColumn = new DataColumn(name);
+            InitialColumn.DataType = dataType;
+            initialDataColumns.Add(InitialColumn);
+        }
+    }
+}

--- a/EncogExtensions/Normalization/EncogAnalystExtensions.cs
+++ b/EncogExtensions/Normalization/EncogAnalystExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Encog.App.Analyst;
+using Encog.App.Analyst.Analyze;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EncogExtensions.Normalization
+{
+    public static class EncogAnalystExtensions
+    {
+        public static void Analyze(this EncogAnalyst analyst, DataSet data)
+        {
+            var a = new PerformAnalysis(analyst.Script);
+            a.Process(analyst, data);// Kiran:2
+        }
+    }
+}

--- a/EncogExtensions/Normalization/ObjectExtensions.cs
+++ b/EncogExtensions/Normalization/ObjectExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Reflection;
+
+namespace EncogExtensions.Normalization
+{
+    // Source("http://www.codeproject.com/Articles/80343/Accessing-private-members.aspx")
+
+    public static class ObjectExtensions
+    {
+        public static T GetPrivateField<T>(this object obj, string name)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            FieldInfo field = type.GetField(name, flags);
+            return (T)field.GetValue(obj);
+        }
+
+        public static T GetPrivateProperty<T>(this object obj, string name)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            PropertyInfo field = type.GetProperty(name, flags);
+            return (T)field.GetValue(obj, null);
+        }
+
+        public static void SetPrivateField(this object obj, string name, object value)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            FieldInfo field = type.GetField(name, flags);
+            field.SetValue(obj, value);
+        }
+
+        public static void SetPrivateProperty(this object obj, string name, object value)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            PropertyInfo field = type.GetProperty(name, flags);
+            field.SetValue(obj, value, null);
+        }
+
+        //Void No Parameters Implementation
+        public static void CallPrivateMethod(this object obj, string name)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            MethodInfo method = type.GetMethod(name, flags);
+            method.Invoke(obj,null);
+        }
+
+        //Void with Parameters Implementation
+        public static void CallPrivateMethod(this object obj, string name, params object[] param)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            MethodInfo method = type.GetMethod(name, flags);
+            method.Invoke(obj, param);
+        }
+
+
+        //No Parameters Implementation
+        public static T CallPrivateMethod<T>(this object obj, string name)
+        {
+            return CallPrivateMethod<T>(obj, name, null);
+        }
+
+        //Parameters and Return Implementation
+        public static T CallPrivateMethod<T>(this object obj, string name, params object[] param)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            Type type = obj.GetType();
+            MethodInfo method = type.GetMethod(name, flags);
+            return (T)method.Invoke(obj, param);
+        }
+    }
+}

--- a/EncogExtensions/Normalization/PerformAnalysis.cs
+++ b/EncogExtensions/Normalization/PerformAnalysis.cs
@@ -1,0 +1,187 @@
+﻿using Encog.App.Analyst;
+using Encog.App.Analyst.Analyze;
+using Encog.App.Analyst.Script;
+using Encog.App.Analyst.Script.Prop;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace EncogExtensions.Normalization
+{
+    public class PerformAnalysis
+    {
+        private Encog.App.Analyst.Analyze.PerformAnalysis _performAnalysis;
+        private AnalystScript _script;
+        private AnalyzedField[] _fields;
+
+        public PerformAnalysis(AnalystScript script)
+        {
+            _script = script;
+        }
+
+        public void Process(EncogAnalyst target, DataSet data)
+        {
+            var count = 0;
+
+            // pass one, calculate the min/max
+            count = PerformCalculateMinMax(data, count);
+
+            // pass two, standard deviation
+            count = PerformStandardDeviation(data, count);
+
+            String str = _script.Properties.GetPropertyString(ScriptProperties.SetupConfigAllowedClasses) ?? "";
+
+            bool allowInt = str.Contains("int");
+            bool allowReal = str.Contains("real") || str.Contains("double");
+            bool allowString = str.Contains("string");
+
+
+            // remove any classes that did not qualify
+            RemoveUnqualifiedClasses(allowInt, allowReal, allowString);
+
+            // merge with existing
+            MergeWithExisting(target);
+
+            // now copy the fields
+            CopyDataFields(target);
+        }
+
+        private void CopyDataFields(EncogAnalyst target)
+        {
+            var df = new DataField[_fields.Length];
+
+            for (int i_4 = 0; i_4 < df.Length; i_4++)
+            {
+                df[i_4] = _fields[i_4].FinalizeField();
+            }
+
+            target.Script.Fields = df;
+        }
+
+        private void MergeWithExisting(EncogAnalyst target)
+        {
+            if ((target.Script.Fields != null)
+                && (_fields.Length == target.Script.Fields.Length))
+            {
+                for (int i = 0; i < _fields.Length; i++)
+                {
+                    // copy the old field name
+                    _fields[i].Name = target.Script.Fields[i].Name;
+
+                    if (_fields[i].Class)
+                    {
+                        IList<AnalystClassItem> t = _fields[i].AnalyzedClassMembers;
+                        IList<AnalystClassItem> s = target.Script.Fields[i].ClassMembers;
+
+                        if (s.Count == t.Count)
+                        {
+                            for (int j = 0; j < s.Count; j++)
+                            {
+                                if (t[j].Code.Equals(s[j].Code))
+                                {
+                                    t[j].Name = s[j].Name;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void RemoveUnqualifiedClasses(bool allowInt, bool allowReal, bool allowString)
+        {
+            foreach (AnalyzedField field in _fields)
+            {
+                if (field.Class)
+                {
+                    if (!allowInt && field.Integer)
+                    {
+                        field.Class = false;
+                    }
+
+                    if (!allowString && (!field.Integer && !field.Real))
+                    {
+                        field.Class = false;
+                    }
+
+                    if (!allowReal && field.Real && !field.Integer)
+                    {
+                        field.Class = false;
+                    }
+                }
+            }
+        }
+
+        private int PerformCalculateMinMax(DataSet data, int count)
+        {
+            for (int counter = 0; counter < data.Tables[0].Rows.Count; counter++)
+            {
+                if (_fields == null)
+                {
+                    GenerateFields(data.Tables[0].Columns);
+                }
+
+                var columnCount = data.Tables[0].Columns.Count;
+                for (int i = 0; i < columnCount; i++)
+                {
+                    if (_fields != null)
+                    {
+                        var str = Convert.ToString(data.Tables[0].Rows[counter][i]);
+                        _fields[i].Analyze1(str);
+                    }
+                }
+                count++;
+            }
+
+            if (count == 0)
+            {
+                throw new AnalystError("Can't analyse data, it is empty.");
+            }
+
+            if (_fields != null)
+            {
+                foreach (AnalyzedField field in _fields)
+                {
+                    field.CompletePass1();
+                }
+            }
+
+            return count;
+        }
+
+        private int PerformStandardDeviation(DataSet data, int count)
+        {
+            for (int counter = 0; counter < data.Tables[0].Rows.Count; counter++)
+            {
+                var columnCount = data.Tables[0].Columns.Count;
+                for (int i = 0; i < columnCount; i++)
+                {
+                    if (_fields != null)
+                    {
+                        _fields[i].Analyze2(Convert.ToString(data.Tables[0].Rows[0][i]));
+                    }
+                }
+                count++;
+            }
+
+            if (_fields != null)
+            {
+                foreach (AnalyzedField field in _fields)
+                {
+                    field.CompletePass2();
+                }
+            }
+
+            return count;
+        }
+
+        private void GenerateFields(DataColumnCollection columns)
+        {
+            _fields = new AnalyzedField[columns.Count];
+            for (int i = 0; i < _fields.Length; i++)
+            {
+                _fields[i] = new AnalyzedField(_script, "field:" + (i + 1));
+            }
+        }
+    }
+}

--- a/EncogExtensions/Properties/AssemblyInfo.cs
+++ b/EncogExtensions/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EncogExtensions")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EncogExtensions")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2c10eb93-d43a-4ce8-b42e-d4eaaacd2e67")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EncogExtensions/encog-extensions.csproj
+++ b/EncogExtensions/encog-extensions.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EncogExtensions</RootNamespace>
+    <AssemblyName>encog-extensions</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Normalization\AnalystNormalizeDataSet.cs" />
+    <Compile Include="Normalization\AnalystWizardExtensions.cs" />
+    <Compile Include="Normalization\DatasetExtensions.cs" />
+    <Compile Include="Normalization\EncogAnalystExtensions.cs" />
+    <Compile Include="Normalization\ObjectExtensions.cs" />
+    <Compile Include="Normalization\PerformAnalysis.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="readme.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\encog-core-cs\encog-core-cs.csproj">
+      <Project>{ac6fadf9-0904-4ebd-b22c-1c787c7e7a95}</Project>
+      <Name>encog-core-cs</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/EncogExtensions/readme.txt
+++ b/EncogExtensions/readme.txt
@@ -1,0 +1,22 @@
+﻿Encog Extensions Library
+
+Personally I found myself in a situation where I needed to use normalization with randomized 
+in memory data. The data could not be saved to a CSV as this would conflict with another frameworks
+persistence mechanism.
+
+The encog analyst is fantastic for normalizing data. It can take information stored in a CSV file
+and automatically determine the normalized fields and their type of encoding 
+(including 1 of N equilateral encoding). 
+
+The only downside of this is that the logic is tightly coupled with the ReadCSV class.
+Favouring extension as opposed to modification I decided to go about creating extension methods and
+alternative classes to create an analyst that would normalize a generic .NET dataset. 
+
+At the moment this logic is a partial re-write of the existing encog analyst. For this reason
+much of the code is duplicated (which I appreciate is a bad thing). My intention is to eventually 
+bake the logic directly into encog-core-cs by modifying the existing implementation.
+
+
+
+
+

--- a/encog-core-cs.sln
+++ b/encog-core-cs.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encog-core-cs", "encog-core-cs\encog-core-cs.csproj", "{AC6FADF9-0904-4EBD-B22C-1C787C7E7A95}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleExamples", "ConsoleExamples\ConsoleExamples.csproj", "{A65A5878-6336-4ACF-9C40-540F8FAF2CC7}"
@@ -14,10 +16,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encog-extensions", "EncogExtensions\encog-extensions.csproj", "{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encog-extensions-test", "encog-extensions-test\encog-extensions-test.csproj", "{01E14205-D596-4580-ACD1-C23716D63516}"
+EndProject
 Global
-	GlobalSection(TestCaseManagementSettings) = postSolution
-		CategoryFile = encog-core-cs.vsmdi
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -57,8 +60,35 @@ Global
 		{7E02C68C-3412-4C39-BF1E-ECA40CEBA6B8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{7E02C68C-3412-4C39-BF1E-ECA40CEBA6B8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{7E02C68C-3412-4C39-BF1E-ECA40CEBA6B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C10EB93-D43A-4CE8-B42E-D4EAAACD2E67}.Release|x86.Build.0 = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Debug|x86.Build.0 = Debug|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|x86.ActiveCfg = Release|Any CPU
+		{01E14205-D596-4580-ACD1-C23716D63516}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = encog-core-cs.vsmdi
 	EndGlobalSection
 EndGlobal

--- a/encog-core-cs/ML/EA/Train/BasicEA.cs
+++ b/encog-core-cs/ML/EA/Train/BasicEA.cs
@@ -376,6 +376,16 @@ namespace Encog.ML.EA.Train
 
             // purge invalid genomes
             Population.PurgeInvalidGenomes();
+
+            PostIteration();
+        }
+
+        /// <summary>
+        /// post iteration added to support strategies.
+        /// </summary>
+        public virtual void PostIteration()
+        {
+
         }
 
         /// <summary>

--- a/encog-core-cs/ML/Train/Strategy/End/EndTimeSpanStrategy.cs
+++ b/encog-core-cs/ML/Train/Strategy/End/EndTimeSpanStrategy.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Encog.ML.Train.Strategy.End
+{
+    /// <summary>
+    /// This End time span strategy gives greater specificity than EndMinutesStrategy. 
+    /// You can specify Days, Hours, Minutes, Seconds etc...
+    /// </summary>
+    public class EndTimeSpanStrategy : IEndTrainingStrategy
+    {
+        private TimeSpan _duration;
+        private bool _started;
+        private DateTime _startedTime;
+       
+        /// <inheritdoc/>
+        public EndTimeSpanStrategy(TimeSpan duration)
+        {
+            _duration = duration;
+        }
+        public void Init(IMLTrain train)
+        {
+            _started = true;
+            _startedTime = DateTime.Now;
+        }
+        
+        /// <inheritdoc/>
+        public void PostIteration()
+        {
+
+        }
+
+        /// <inheritdoc/>
+        public void PreIteration()
+        {
+        
+        }
+
+        /// <inheritdoc/>
+        public virtual bool ShouldStop()
+        {
+            lock (this)
+            {
+                return (DateTime.Now.Subtract(_startedTime) > _duration);
+            }
+        }
+    }
+}

--- a/encog-core-cs/encog-core-cs.csproj
+++ b/encog-core-cs/encog-core-cs.csproj
@@ -575,6 +575,7 @@
     <Compile Include="ML\Prg\VariableMapping.cs" />
     <Compile Include="ML\TrainingImplementationType.cs" />
     <Compile Include="ML\Train\Strategy\EarlyStoppingStrategy.cs" />
+    <Compile Include="ML\Train\Strategy\End\EndTimeSpanStrategy.cs" />
     <Compile Include="ML\Train\Strategy\End\SimpleEarlyStoppingStrategy.cs" />
     <Compile Include="ML\Tree\Basic\BasicTreeNode.cs" />
     <Compile Include="ML\Tree\ITreeNode.cs" />

--- a/encog-extensions-test/Properties/AssemblyInfo.cs
+++ b/encog-extensions-test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("encog-extensions-test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("encog-extensions-test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("01e14205-d596-4580-acd1-c23716d63516")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/encog-extensions-test/TestDataSetNormalization.cs
+++ b/encog-extensions-test/TestDataSetNormalization.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Encog.ML.Data.Market;
+using Encog.ML.Data.Market.Loader;
+using Encog.App.Analyst;
+using Encog.App.Analyst.Wizard;
+using EncogExtensions.Normalization;
+using System.Data;
+using System.Linq;
+using Encog.Util.Arrayutil;
+
+namespace encog_extensions_test
+{
+    [TestClass]
+    public class TestDataSetNormalization
+    {
+        public object ArrayUtil { get; private set; }
+
+        [TestMethod]
+        public void Normalize_Some_In_Memory_Data()
+        {
+            List<LoadedMarketData> MarketData = new List<LoadedMarketData>();
+            MarketData.AddRange(DownloadStockData("MSFT",TimeSpan.FromDays(10)));
+            MarketData.AddRange(DownloadStockData("AAPL", TimeSpan.FromDays(10)));
+            MarketData.AddRange(DownloadStockData("YHOO", TimeSpan.FromDays(10)));
+
+            // Convert stock data to dataset using encog-extensions
+            DataSet dataSet = new DataSet().Convert(MarketData, "Market DataSet");
+
+            // use encog-extensions to normalize the dataset 
+            var analyst = new EncogAnalyst();
+            var wizard = new AnalystWizard(analyst);
+            wizard.Wizard(dataSet);
+
+            // DataSet Goes In... 2D Double Array Comes Out... 
+            var normalizer = new AnalystNormalizeDataSet(analyst);
+            var normalizedData = normalizer.Normalize(dataSet);
+         
+            // Assert data is not null and differs from original
+            Assert.IsNotNull(normalizedData);
+            Assert.AreNotEqual(normalizedData[0, 0], dataSet.Tables[0].Rows[0][0]);
+
+        }
+
+        private static List<LoadedMarketData> DownloadStockData(string stockTickerSymbol,TimeSpan timeSpan)
+        {
+            IList<MarketDataType> dataNeeded = new List<MarketDataType>();
+            dataNeeded.Add(MarketDataType.AdjustedClose);
+            dataNeeded.Add(MarketDataType.Close);
+            dataNeeded.Add(MarketDataType.Open);
+            dataNeeded.Add(MarketDataType.High);
+            dataNeeded.Add(MarketDataType.Low);
+            dataNeeded.Add(MarketDataType.Volume);
+
+            List<LoadedMarketData> MarketData =
+                new YahooFinanceLoader().Load(
+                    new TickerSymbol(stockTickerSymbol),
+                    dataNeeded,
+                    DateTime.Now.Subtract(timeSpan),
+                    DateTime.Now).ToList();
+
+            return MarketData;
+        }
+    }
+}

--- a/encog-extensions-test/encog-extensions-test.csproj
+++ b/encog-extensions-test/encog-extensions-test.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{01E14205-D596-4580-ACD1-C23716D63516}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>encog_extensions_test</RootNamespace>
+    <AssemblyName>encog-extensions-test</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="TestDataSetNormalization.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\encog-core-cs\encog-core-cs.csproj">
+      <Project>{ac6fadf9-0904-4ebd-b22c-1c787c7e7a95}</Project>
+      <Name>encog-core-cs</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EncogExtensions\encog-extensions.csproj">
+      <Project>{2c10eb93-d43a-4ce8-b42e-d4eaaacd2e67}</Project>
+      <Name>encog-extensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Encog Extensions Library

Personally I found myself in a situation where I needed to use normalization with randomized 
in memory data. The data could not be saved to a CSV as this would conflict with another frameworks
persistence mechanism.

The encog analyst is fantastic for normalizing data. It can take information stored in a CSV file
and automatically determine the normalized fields and their type of encoding 
(including 1 of N equilateral encoding). 

The only downside of this is that the logic is tightly coupled with the ReadCSV class.
Favouring extension as opposed to modification I decided to go about creating extension methods and
alternative classes to create an analyst that would normalize a generic .NET dataset. 

At the moment this logic is a partial re-write of the existing encog analyst. For this reason
much of the code is duplicated (which I appreciate is a bad thing). My intention is to eventually 
bake the logic directly into encog-core-cs by modifying the existing implementation. For now the code is there to be used when needed.