### PR TITLE
Speedup LoadObject using a Dictionary<string, Type>.

### DIFF
--- a/encog-core-cs/Neural/NEAT/NEATPopulation.cs
+++ b/encog-core-cs/Neural/NEAT/NEATPopulation.cs
@@ -184,6 +184,18 @@ namespace Encog.Neural.NEAT
         public IGeneticCODEC CODEC { get; set; }
 
         /// <summary>
+        /// The actual best network.
+        /// </summary>
+        public NEATNetwork BestNetwork
+        {
+            get
+            {
+                UpdateBestNetwork();
+                return _bestNetwork;
+            }
+        }
+
+        /// <summary>
         /// The initial connection density for the initial random population of
         /// genomes.
         /// </summary>
@@ -397,7 +409,7 @@ namespace Encog.Neural.NEAT
             // create the initial population
             for (int i = 0; i < PopulationSize; i++)
             {
-                NEATGenome genome = GenomeFactory.Factor(rnd, this ,
+                NEATGenome genome = GenomeFactory.Factor(rnd, this,
                         InputCount, OutputCount,
                         InitialConnectionDensity);
                 defaultSpecies.Add(genome);

--- a/encog-core-cs/Util/ReflectionUtil.cs
+++ b/encog-core-cs/Util/ReflectionUtil.cs
@@ -50,6 +50,11 @@ namespace Encog.Util
         private static readonly IDictionary<String, String> ClassMap = new Dictionary<String, String>();
 
         /// <summary>
+        /// A map between short class names and the corresponding type.
+        /// </summary>
+        private static readonly IDictionary<String, Type> TypeMap = new Dictionary<String, Type>();
+
+        /// <summary>
         /// Private constructor.
         /// </summary>
         private ReflectionUtil()
@@ -182,12 +187,22 @@ namespace Encog.Util
         /// <returns>The created class.</returns>
         public static Object LoadObject(String name)
         {
+            Type type;
+            if (TypeMap.TryGetValue(name, out type))
+                return Activator.CreateInstance(type);
+
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
             Object result = null;
 
             foreach (Assembly a in assemblies)
             {
-                result = a.CreateInstance(name);
+                type = a.GetType(name);
+                if (type != null)
+                {
+                    TypeMap[name] = type;
+                    result = Activator.CreateInstance(type);
+                }
+
                 if (result != null)
                     break;
             }


### PR DESCRIPTION
Increases performance when deserializing big NEAT Populations drastically.

I have really big NEAT networks. When deserializing these networks, the performance bottleneck is 

` EncogFileSection.ParseActivationFunction(...);`

Using this pull request the performace can be speed up by using a type cache.