### PR TITLE
Update ParseCSVLine.cs to fix the behaviour in case of null or missing values

### DIFF
--- a/encog-core-cs/Util/CSV/ParseCSVLine.cs
+++ b/encog-core-cs/Util/CSV/ParseCSVLine.cs
@@ -65,6 +65,11 @@ namespace Encog.Util.CSV
                 char ch = line[i];
                 if ((ch == Format.Separator) && !quoted)
                 {
+                    //If value is empty string, that means value is missing, in Encog terms unkown or missing value is represnted with "?"
+                    if (item.Length == 0)
+                    {
+                        item.Append("?");
+                    }
                     String s = item.ToString();
                     if (!hadQuotes)
                     {
@@ -72,6 +77,8 @@ namespace Encog.Util.CSV
                     }
                     result.Add(s);
                     item.Length = 0;
+                    //We just process "a seperator" that means we are expecting value after the sperator, if it does not present then "?" is going to be the default value. which means missing value in Encog terms.
+                    item.Append("?");
                     quoted = false;
                     hadQuotes = false;
                 }
@@ -86,6 +93,11 @@ namespace Encog.Util.CSV
                 }
                 else
                 {
+                    //We found as valid value so remove the missing value character.
+                    if (item.ToString() == "?")
+                    {
+                        item.Length--;
+                    }
                     item.Append(ch);
                 }
             }


### PR DESCRIPTION
I am using this program in stock prediction and this is a common scenario in the stock prediction that value of some new ticker may be unknown.

First case: first expected value is missing in CSV, In this case, the first line was having less number of columns than the current line.
//Sample data
//0,0,
//0,1,1
//1,0,1
//1,1,0
Second case: after first-line expected value is missing in CSV, In this case, the previous line was having more columns than current line, So reset the array so that it does not carry the old values into missing column.
//Sample data
//0,0,0
//0,1,
//1,0,1
//1,1,0

This fix is going to treat missing values as "?" which is a native representation of missing values in Encog Framework